### PR TITLE
Runs npm audit fix And Updates lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyn/immutable",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -757,9 +757,9 @@
       }
     },
     "@polyn/blueprint": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@polyn/blueprint/-/blueprint-2.4.0.tgz",
-      "integrity": "sha512-Q4ImcAWHHrfuiTltzwTwzomAFx/cDZxND0fOKLqG/tXIs2k2sjhjbloaZetDXzkxsiFT/DNYPoaEv1tVqr9ByA=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@polyn/blueprint/-/blueprint-2.4.1.tgz",
+      "integrity": "sha512-egpGS3uN4RjgOemQC47PipCIzuIePC91zBNScS0VD/8oaHup79RwIU6rCpJnNb1yMMObyJw6YSvmfYhFKUUQOg=="
     },
     "@types/chai": {
       "version": "4.1.7",
@@ -1781,9 +1781,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "loose-envify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyn/immutable",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Define object schema's for validation, and construction of immutable objects",
   "main": "index.js",
   "types": "index.d.ts",
@@ -53,6 +53,6 @@
     "uuid": "~3.3.2"
   },
   "dependencies": {
-    "@polyn/blueprint": "~2.4.0"
+    "@polyn/blueprint": "~2.4.1"
   }
 }


### PR DESCRIPTION
This package only has devDependencies, not including
dependencies on other polyn projects, so consumers
were not subject to any of the vulnerabilities that
are fixed in this update.