### PR TITLE
fix: fixes the publish gh action

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "pre-push": [
     "lint",
-    "test",
+    "test:ci",
     "pre-push"
   ],
   "repository": {


### PR DESCRIPTION
The pre-push hooks ran the tests in TTY mode instead of CI mode, which kept the publishing action from completing. This should fix that.